### PR TITLE
Set HTTP status 200 on preflight requests

### DIFF
--- a/classes/HandlePreflight.php
+++ b/classes/HandlePreflight.php
@@ -33,7 +33,7 @@ class HandlePreflight
             $preflight = $this->cors->handlePreflightRequest($request);
             $response->headers->add($preflight->headers->all());
         }
-        $response->setStatusCode(200);
+        $response->setStatusCode(204);
         return $response;
     }
 

--- a/classes/HandlePreflight.php
+++ b/classes/HandlePreflight.php
@@ -33,7 +33,7 @@ class HandlePreflight
             $preflight = $this->cors->handlePreflightRequest($request);
             $response->headers->add($preflight->headers->all());
         }
-
+        $response->setStatusCode(200);
         return $response;
     }
 


### PR DESCRIPTION
Fixes the bug described in this thread: https://octobercms.com/forum/post/enabling-cors-specifically-preflight-options
```
OPTIONS http://connectapi.localhost/api/login 404 (Not Found)

Access to XMLHttpRequest at 'http://connectapi.localhost/api/login' from origin 'http://connectfe.localhost' has been blocked >by CORS policy: Response to preflight request doesn't pass access control check: It does not have HTTP ok status.
```